### PR TITLE
chore: add fail message for yarn spec

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -73,6 +73,7 @@ jobs:
           then
             exit 0
           else
+            echo "Your API specification has changed when running yarn spec. Make sure you commit your API spec changes, or remove unintended changes in the properties definition"
             exit 1
           fi
 


### PR DESCRIPTION
If you don't push your updated api spec, you get a succeed printout then it fails, with no info. Had to look at the source code in here to figure out why. So added an echo for some context. Not sure if the wording is accurate