### PR TITLE
fix: build version

### DIFF
--- a/actions/semantic-release/release.config.cjs
+++ b/actions/semantic-release/release.config.cjs
@@ -13,7 +13,7 @@ const config = {
     [
       "@semantic-release/exec",
       {
-        prepareCmd: "yarn spec",
+        prepareCmd: "yarn spec && yarn build",
         successCmd: "$GITHUB_ACTION_PATH/api-compliance.sh ${nextRelease.version}",
       },
     ],


### PR DESCRIPTION
Currently the `build` step is executed before the new release version have been established. This means that the release package contains the wrong package version in the `qext` file, "banner" in bundled file and the initial properties of the object.

I think this will solve it as the `package.json` should at this stage have been updated with the new release version.