### PR TITLE
fix: use correct tag api compliance

### DIFF
--- a/actions/release-it/.release-it.js
+++ b/actions/release-it/.release-it.js
@@ -74,7 +74,7 @@ module.exports = {
       `git add ${assets}`,
     ],
     "after:git:release": [
-      `${actionPath}/api-compliance.sh ${version}`,
+      `${actionPath}/api-compliance.sh ${tagName}`,
       "git reset --hard",
       "git clean -df",
       "git status",

--- a/actions/release-it/api-compliance.sh
+++ b/actions/release-it/api-compliance.sh
@@ -5,7 +5,7 @@ if [ -z "$CURRENT_API_KEY" ]; then
   exit 0
 fi
 
-version=$1
+tag=$1
 docker pull ghcr.io/qlik-download/api-compliance
 docker create -v /specs --name specs alpine:3.4 "/bin/true"
 docker cp "$API_SPECIFICATION_PATH" specs:/specs/properties.json
@@ -13,7 +13,7 @@ docker cp "$API_SPECIFICATION_PATH" specs:/specs/properties.json
 docker run --volumes-from specs \
   -e SPEC_PATHS="$CURRENT_API_KEY@/specs/properties.json" \
   -e COMMIT_SHA="$(git rev-parse HEAD)" \
-  -e RELEASE_TAG="$version" \
+  -e RELEASE_TAG="$tag" \
   -e CREDENTIALS_S3_SECRETKEY="$APICULTURIST_S3" \
   -e CREDENTIALS_GITHUB="$APICULTURIST_GITHUB" \
   -e CREDENTIALS_COLONY="$APICULTURIST_TOKEN" \


### PR DESCRIPTION
This will not fix the issue we see in monorepos I think because the first part of the tag will be stripped anyway. However we should send in the correct tag of course and then talk with api compliance to see if we can enable this setup for us