### PR TITLE
feat: check for correct nebula peer dep semver

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -53,7 +53,7 @@ jobs:
                 throw "Nebula peer dependency missing"
               }
               if(peerDeps["@nebula.js/stardust"].substr(0,1) !== ">") {
-                throw "Incorrect Nebula peer dependecy semver check"
+                throw "Incorrect Nebula peer dependecy semver check, please use the form >=X.Y.Z and not ^X.Y.Z"
               }
 
               return Object.keys(package.scripts)

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -48,6 +48,14 @@ jobs:
               const fs = require('fs')
               const jsonString = fs.readFileSync('./package.json')
               var package = JSON.parse(jsonString)
+              var peerDeps = package.peerDependencies;
+              if(!peerDeps["@nebula.js/stardust"]) {
+                throw "Nebula peer dependency missing"
+              }
+              if(peerDeps["@nebula.js/stardust"].substr(0,1) !== ">") {
+                throw "Incorrect Nebula peer dependecy semver check"
+              }
+
               return Object.keys(package.scripts)
             } catch(err) {
               core.error("Error while reading or parsing the JSON")

--- a/package.json
+++ b/package.json
@@ -18,6 +18,6 @@
     "test:e2e:report": "echo test:e2e:report"
   },
   "peerDependencies": {
-    "@nebula.js/stardust": "^1.2.3"
+    "@nebula.js/stardust": ">=1.2.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,5 +16,8 @@
     "start": "echo start",
     "test:e2e": "echo test:e2e",
     "test:e2e:report": "echo test:e2e:report"
+  },
+  "peerDependencies": {
+    "@nebula.js/stardust": ">=1.2.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,6 @@
     "test:e2e:report": "echo test:e2e:report"
   },
   "peerDependencies": {
-    "@nebula.js/stardust": ">=1.2.3"
+    "@nebula.js/stardust": "^1.2.3"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3,3 +3,20 @@ lockfileVersion: '6.0'
 settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
+
+dependencies:
+  '@nebula.js/stardust':
+    specifier: '>=1.2.3'
+    version: 4.14.0
+
+packages:
+
+  /@nebula.js/stardust@4.14.0:
+    resolution: {integrity: sha512-OrO95DS2QxWOUaZbWSNMzzMtBCwi65Y+G4SWPJ5hNH4MAAhIPbaQN8NT142RpcKSLCzctqEBwLiG16NxHZFkrw==}
+    dependencies:
+      '@types/qlik-engineapi': 12.67.16
+    dev: false
+
+  /@types/qlik-engineapi@12.67.16:
+    resolution: {integrity: sha512-NiwMX6zrV162lRcupTdrgoT2YtKZy97zJ70rRGLdJTWcaMOWUgAhM1ufzhmp3ir1KlNArI4Ds8ojfxA80SpwKQ==}
+    dev: false


### PR DESCRIPTION
I want to make sure we release the charts with correct peer dependency settings:
Do:
```
  "peerDependencies": {
    "@nebula.js/stardust": ">=4.6.1"
  }
```
Don't:
```
  "peerDependencies": {
    "@nebula.js/stardust": "^4.6.1"
  }
```

As we can't make breaking changes to the extensions API, we can also not lock the charts to older version of Nebula. The `^` will not include the next major, which force us to update all charts to be able to update Nebula.
