### PR TITLE
fix: playwright install with deps

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -99,7 +99,7 @@ jobs:
       - name: Run Playwright tests
         if: contains(fromJSON(needs.read_package.outputs.scripts), 'test:e2e' )
         run: |
-          npx playwright install
+          npx playwright install --with-deps
           ${{ inputs.package_manager }} run test:e2e
 
       - name: Upload results Playwright tests


### PR DESCRIPTION
Warnings about `Host system is missing dependencies to run browsers` are being logged while running e2e tests. I suspect that is because the system deps are not installed.

https://playwright.dev/docs/browsers#install-system-dependencies
https://playwright.dev/docs/ci-intro#on-pushpull_request