### PR TITLE
fix: remove mvm from workflows and update release-it

### DIFF
--- a/actions/release-it/.release-it.js
+++ b/actions/release-it/.release-it.js
@@ -67,7 +67,6 @@ module.exports = {
   hooks: {
     "before:git:release": [
       "git clean -df",
-      `if ${monorepo}; then mvm-update && git add mvm.lock || echo "Did not update mvm.lock"; fi`,
       `#!/bin/bash
       if [ -n "$(node ${actionPath}/check-version)" ]; then exit 1; fi`,
       `if ${specCommand}; then ${packageManager} run spec && ${packageManager} run build; fi`,

--- a/actions/release-it/action.yaml
+++ b/actions/release-it/action.yaml
@@ -51,7 +51,7 @@ runs:
         branch_name=$(git rev-parse --abbrev-ref HEAD)
         echo "branch_name=$branch_name" >> $GITHUB_ENV
         echo "action_path=${GITHUB_ACTION_PATH}" >> $GITHUB_ENV
-        ${{ inputs.package_manager }} install --global @release-it/conventional-changelog@7.0.2 release-it@16.2.1
+        ${{ inputs.package_manager }} install --global @release-it/conventional-changelog@8.0.1 release-it@17.2.0
     - name: Release it
       env:
         GITHUB_TOKEN: ${{ inputs.GH_TOKEN }}

--- a/actions/release-it/action.yaml
+++ b/actions/release-it/action.yaml
@@ -51,7 +51,7 @@ runs:
         branch_name=$(git rev-parse --abbrev-ref HEAD)
         echo "branch_name=$branch_name" >> $GITHUB_ENV
         echo "action_path=${GITHUB_ACTION_PATH}" >> $GITHUB_ENV
-        ${{ inputs.package_manager }} install --global @release-it/conventional-changelog@7.0.2 release-it@16.2.1 @b12k/mvm@0.0.10
+        ${{ inputs.package_manager }} install --global @release-it/conventional-changelog@7.0.2 release-it@16.2.1
     - name: Release it
       env:
         GITHUB_TOKEN: ${{ inputs.GH_TOKEN }}


### PR DESCRIPTION
Mvm was supposed to update the internal dependencies for monorepos. However all monorepos are setting the internal dependency as `workspace:*` 