### PR TITLE
fix!: force pnpm version to be defined in package.json

### DIFF
--- a/actions/setup/action.yaml
+++ b/actions/setup/action.yaml
@@ -60,8 +60,6 @@ runs:
     - name: Setup pnpm
       if: inputs.package_manager == 'pnpm'
       uses: pnpm/action-setup@v2
-      with:
-        version: 8
 
     - name: Setup bun
       if: inputs.package_manager == 'bun'


### PR DESCRIPTION

BREAKING CHANGE: pnpm version must be defined in package.json
Signed-off-by: Johan Enell <johan.enell@qlik.com>