### PR TITLE
feat!: node version should be defined in file

### DIFF
--- a/actions/scan-packages/action.yaml
+++ b/actions/scan-packages/action.yaml
@@ -28,7 +28,7 @@ runs:
         if [ "$scripts" != "null"  ]; then
           echo 'scripts=$scripts' >> "$GITHUB_OUTPUT"
         else
-          echo "::error::Error while reading or parsing the JSON. Couldn't find a script section"
+          echo "::error::Couldn't find a script section in package.json"
         fi
 
     - name: Verify stardust

--- a/actions/setup/action.yaml
+++ b/actions/setup/action.yaml
@@ -54,7 +54,7 @@ runs:
     - name: Setup Node
       uses: actions/setup-node@v4
       with:
-        node-version: 18
+        node-version-file: package.json
         cache: pnpm
 
     - name: Install dependencies

--- a/package.json
+++ b/package.json
@@ -19,5 +19,7 @@
   },
   "peerDependencies": {
     "@nebula.js/stardust": ">=1.2.3"
-  }
+  },
+  "packageManager": "pnpm@^6",
+  "engines": {"node": "^18"}
 }


### PR DESCRIPTION
This change will add requirement that the repo has defined the node version to be used in either package.json, .node-version or .nvmrc

https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#node-version-file